### PR TITLE
hid report behaviour and 6-key implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ keymap = [
 ]
 ```
 
-You can now initialize an `AFK.State` struct and press and release keys. Calling
-`to_hid_report/1` returns a byte string for sending to a HID interface
-configured as a basic 6-key rollover USB keyboard.
+You can now initialize an `AFK.State` struct and press and release keys. Using
+an implementation of the `AFK.HIDReport` behaviour and calling `hid_report/1`
+returns a byte string for sending to a USB HID interface.
 
 ```elixir
 state = AFK.State.new(keymap)
@@ -63,19 +63,20 @@ state =
   |> AFK.State.press_key(:k002)
   |> AFK.State.press_key(:k001)
 
-AFK.State.to_hid_report(state)
+AFK.HIDReport.SixKeyRollover.hid_report(state)
 # => <<128, 0, 29, 0, 0, 0, 0, 0>>
 
 state = AFK.State.release_key(state, :k002)
 
-AFK.State.to_hid_report(state)
+AFK.HIDReport.SixKeyRollover.hid_report(state)
 # => <<0, 0, 29, 0, 0, 0, 0, 0>>
 ```
 
 ## Future Features
 
-It's intended to eventually support N-key rollover, but for now it just supports
-basic 6-key rollover.
+AFK provides a behaviour for defining how to convert the state into a HID
+report. Currently only a 6-key rollover implementation is provided, but an N-key
+rollover implementation would be a great addition. (Pull requests welcome!)
 
 It may eventually also support more complex interactions, such as sticky keys,
 macros, leader keys, etc. These features require a lot more thinking though, as

--- a/lib/afk/hid_report.ex
+++ b/lib/afk/hid_report.ex
@@ -1,0 +1,12 @@
+defmodule AFK.HIDReport do
+  @moduledoc """
+  Defines a behaviour for converting an `AFK.State` struct into a binary USB HID
+  report.
+
+  Current implementations:
+
+  * `AFK.HIDReport.SixKeyRollover
+  """
+
+  @callback hid_report(AFK.State.t()) :: binary()
+end

--- a/lib/afk/hid_report/six_key_rollover.ex
+++ b/lib/afk/hid_report/six_key_rollover.ex
@@ -1,0 +1,36 @@
+defmodule AFK.HIDReport.SixKeyRollover do
+  @moduledoc """
+  Implements the `AFK.HIDReport` behaviour to produce a standard 6-key rollover
+  USB keyboard HID report.
+
+  The report is an 8-byte binary with the first byte being a bitmap of modifier
+  keys that are currently active, the second byte being zero (reserved), and the
+  following 6 bytes are the first 6 key scancodes that are active. Any
+  additionally active keys are ignored in this report.
+  """
+
+  @behaviour AFK.HIDReport
+
+  use Bitwise
+
+  import AFK.Scancode, only: [scancode: 1]
+
+  @impl AFK.HIDReport
+  @spec hid_report(AFK.State.t()) :: <<_::64>>
+  def hid_report(%AFK.State{} = state) do
+    modifiers_byte =
+      Enum.reduce(state.modifiers, 0, fn {_, keycode}, acc ->
+        scancode(keycode) ||| acc
+      end)
+
+    [one, two, three, four, five, six] =
+      Enum.map(0..5, fn i ->
+        case state.indexed_keys[i] do
+          nil -> 0
+          {_key, %AFK.Keycode.Key{} = keycode} -> scancode(keycode)
+        end
+      end)
+
+    <<modifiers_byte, 0, one, two, three, four, five, six>>
+  end
+end

--- a/test/support/keycode_case.ex
+++ b/test/support/keycode_case.ex
@@ -4,7 +4,7 @@ defmodule AFK.KeycodeCase do
   use ExUnit.CaseTemplate
   use Bitwise
 
-  alias AFK.State
+  alias AFK.HIDReport.SixKeyRollover
   alias AFK.Keycode.{Key, Modifier}
 
   import AFK.Scancode, only: [scancode: 1]
@@ -25,7 +25,7 @@ defmodule AFK.KeycodeCase do
         %Key{} = keycode -> scancode(keycode)
       end)
 
-    assert <<_, 0, ^one, ^two, ^three, ^four, ^five, ^six>> = State.to_hid_report(state)
+    assert <<_, 0, ^one, ^two, ^three, ^four, ^five, ^six>> = SixKeyRollover.hid_report(state)
   end
 
   # asserts the listed modifiers are active in the HID report.
@@ -33,6 +33,6 @@ defmodule AFK.KeycodeCase do
   def assert_modifiers(state, modifiers) do
     modifier_byte = Enum.reduce(modifiers, 0, fn %Modifier{} = keycode, acc -> scancode(keycode) ||| acc end)
 
-    assert <<^modifier_byte, 0, _, _, _, _, _, _>> = State.to_hid_report(state)
+    assert <<^modifier_byte, 0, _, _, _, _, _, _>> = SixKeyRollover.hid_report(state)
   end
 end


### PR DESCRIPTION
breaking change: you can no longer call `State.to_hid_report/1`; instead
use `AFK.HIDReport.SixKeyRollover.hid_report/1`