### PR TITLE
CI overhaul with better cache keys and act support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           echo ::set-output name=lockfile_key::${{ hashFiles('mix.lock') }}
           echo ::set-output name=build_key::build-${{ runner.os }}-${{ env.MIX_ENV }}
           echo ::set-output name=version_key::${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}
-          echo ::set-output name=files_key::${{ hashFiles('{lib/**/*.ex,test/**/*.ex,mix.lock}') }}
+          echo ::set-output name=files_key::${{ hashFiles('lib/**/*.ex','test/**/*.ex','mix.lock') }}
       - uses: actions/cache@v2.1.0
         id: deps_cache
         with:
@@ -88,7 +88,7 @@ jobs:
           echo ::set-output name=lockfile_key::${{ hashFiles('mix.lock') }}
           echo ::set-output name=build_key::build-${{ runner.os }}-${{ env.MIX_ENV }}
           echo ::set-output name=version_key::${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}
-          echo ::set-output name=files_key::${{ hashFiles('{lib/**/*.ex,test/**/*.ex,mix.lock}') }}
+          echo ::set-output name=files_key::${{ hashFiles('lib/**/*.ex','test/**/*.ex','mix.lock') }}
       - uses: actions/cache@v2.1.0
         id: deps_cache
         with:
@@ -139,7 +139,7 @@ jobs:
           echo ::set-output name=lockfile_key::${{ hashFiles('mix.lock') }}
           echo ::set-output name=build_key::build-${{ runner.os }}-${{ env.MIX_ENV }}
           echo ::set-output name=version_key::${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}
-          echo ::set-output name=files_key::${{ hashFiles('{lib/**/*.ex,test/**/*.ex,mix.lock}') }}
+          echo ::set-output name=files_key::${{ hashFiles('lib/**/*.ex','test/**/*.ex','mix.lock') }}
       - uses: actions/cache@v2.1.0
         id: deps_cache
         with:
@@ -188,7 +188,7 @@ jobs:
           echo ::set-output name=lockfile_key::${{ hashFiles('mix.lock') }}
           echo ::set-output name=build_key::build-${{ runner.os }}-${{ env.MIX_ENV }}
           echo ::set-output name=version_key::${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}
-          echo ::set-output name=files_key::${{ hashFiles('{lib/**/*.ex,test/**/*.ex,mix.lock}') }}
+          echo ::set-output name=files_key::${{ hashFiles('lib/**/*.ex','test/**/*.ex','mix.lock') }}
       - uses: actions/cache@v2.1.0
         id: deps_cache
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,38 +29,41 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # shared steps
       - uses: actions/checkout@v2
       - uses: doughsay/setup-elixir@1148b8ff819424a2efa48ff89af3ccc114c1fc39
         id: setup
         with:
           otp-version: ${{ env.OTP_VERSION_SPEC }}
           elixir-version: ${{ env.ELIXIR_VERSION_SPEC }}
-      - uses: actions/cache@v2.1.0
-        id: cache_deps
-        with:
-          path: deps
-          key: ${{ runner.os }}-${{ hashFiles('mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-
       - name: Cache Keys
         id: keys
         run: |
-          echo ::set-output name=env_key::${{ runner.os }}-${{ env.MIX_ENV }}
+          echo ::set-output name=deps_key::deps-${{ runner.os }}
+          echo ::set-output name=lockfile_key::${{ hashFiles('mix.lock') }}
+          echo ::set-output name=build_key::build-${{ runner.os }}-${{ env.MIX_ENV }}
           echo ::set-output name=version_key::${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}
           echo ::set-output name=files_key::${{ hashFiles('{lib/**/*.ex,test/**/*.ex,mix.lock}') }}
       - uses: actions/cache@v2.1.0
-        id: cache_build
+        id: deps_cache
+        with:
+          path: deps
+          key: ${{ steps.keys.outputs.deps_key }}-${{ steps.keys.outputs.lockfile_key }}
+          restore-keys: |
+            ${{ steps.keys.outputs.deps_key }}-
+      - uses: actions/cache@v2.1.0
+        id: build_cache
         with:
           path: _build
-          key: ${{ steps.keys.outputs.env_key }}-${{ steps.keys.outputs.version_key }}-${{ steps.keys.outputs.files_key }}
+          key: ${{ steps.keys.outputs.build_key }}-${{ steps.keys.outputs.version_key }}-${{ steps.keys.outputs.files_key }}
           restore-keys: |
-            ${{ steps.keys.outputs.env_key }}-${{ steps.keys.outputs.version_key }}-
-            ${{ steps.keys.outputs.env_key }}-
+            ${{ steps.keys.outputs.build_key }}-${{ steps.keys.outputs.version_key }}-
+            ${{ steps.keys.outputs.build_key }}-
       - name: Install dependencies
-        if: steps.cache_deps.outputs['cache-hit'] != 'true'
+        if: steps.deps_cache.outputs['cache-hit'] != 'true'
         run: mix deps.get
       - name: Compile
-        if: steps.cache_build.outputs['cache-hit'] != 'true'
+        if: steps.build_cache.outputs['cache-hit'] != 'true'
         run: mix compile --warnings-as-errors
 
   test:
@@ -71,42 +74,47 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # shared steps
       - uses: actions/checkout@v2
       - uses: doughsay/setup-elixir@1148b8ff819424a2efa48ff89af3ccc114c1fc39
         id: setup
         with:
-          otp-version: "23.x"
-          elixir-version: "1.10.x"
-      - uses: actions/cache@v2.1.0
-        id: cache_deps
-        with:
-          path: deps
-          key: ${{ runner.os }}-${{ hashFiles('mix.lock') }}
+          otp-version: ${{ env.OTP_VERSION_SPEC }}
+          elixir-version: ${{ env.ELIXIR_VERSION_SPEC }}
       - name: Cache Keys
         id: keys
         run: |
-          echo ::set-output name=env_key::${{ runner.os }}-${{ env.MIX_ENV }}
+          echo ::set-output name=deps_key::deps-${{ runner.os }}
+          echo ::set-output name=lockfile_key::${{ hashFiles('mix.lock') }}
+          echo ::set-output name=build_key::build-${{ runner.os }}-${{ env.MIX_ENV }}
           echo ::set-output name=version_key::${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}
           echo ::set-output name=files_key::${{ hashFiles('{lib/**/*.ex,test/**/*.ex,mix.lock}') }}
       - uses: actions/cache@v2.1.0
-        id: cache_build
+        id: deps_cache
+        with:
+          path: deps
+          key: ${{ steps.keys.outputs.deps_key }}-${{ steps.keys.outputs.lockfile_key }}
+          restore-keys: |
+            ${{ steps.keys.outputs.deps_key }}-
+      - uses: actions/cache@v2.1.0
+        id: build_cache
         with:
           path: _build
-          key: ${{ steps.keys.outputs.env_key }}-${{ steps.keys.outputs.version_key }}-${{ steps.keys.outputs.files_key }}
+          key: ${{ steps.keys.outputs.build_key }}-${{ steps.keys.outputs.version_key }}-${{ steps.keys.outputs.files_key }}
           restore-keys: |
-            ${{ steps.keys.outputs.env_key }}-${{ steps.keys.outputs.version_key }}-
-            ${{ steps.keys.outputs.env_key }}-
+            ${{ steps.keys.outputs.build_key }}-${{ steps.keys.outputs.version_key }}-
+            ${{ steps.keys.outputs.build_key }}-
       - name: Install dependencies
-        if: steps.cache_deps.outputs['cache-hit'] != 'true'
+        if: steps.deps_cache.outputs['cache-hit'] != 'true'
         run: mix deps.get
       - name: Compile
-        if: steps.cache_build.outputs['cache-hit'] != 'true'
-        run: mix compile
+        if: steps.build_cache.outputs['cache-hit'] != 'true'
+        run: mix compile --warnings-as-errors
+      # job steps
       - name: Run tests
         run: mix coveralls.json
       - uses: codecov/codecov-action@v1
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
           fail_ci_if_error: true
 
   credo:
@@ -117,37 +125,43 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # shared steps
       - uses: actions/checkout@v2
       - uses: doughsay/setup-elixir@1148b8ff819424a2efa48ff89af3ccc114c1fc39
         id: setup
         with:
-          otp-version: "23.x"
-          elixir-version: "1.10.x"
-      - uses: actions/cache@v2.1.0
-        id: cache_deps
-        with:
-          path: deps
-          key: ${{ runner.os }}-${{ hashFiles('mix.lock') }}
+          otp-version: ${{ env.OTP_VERSION_SPEC }}
+          elixir-version: ${{ env.ELIXIR_VERSION_SPEC }}
       - name: Cache Keys
         id: keys
         run: |
-          echo ::set-output name=env_key::${{ runner.os }}-${{ env.MIX_ENV }}
+          echo ::set-output name=deps_key::deps-${{ runner.os }}
+          echo ::set-output name=lockfile_key::${{ hashFiles('mix.lock') }}
+          echo ::set-output name=build_key::build-${{ runner.os }}-${{ env.MIX_ENV }}
           echo ::set-output name=version_key::${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}
           echo ::set-output name=files_key::${{ hashFiles('{lib/**/*.ex,test/**/*.ex,mix.lock}') }}
       - uses: actions/cache@v2.1.0
-        id: cache_build
+        id: deps_cache
+        with:
+          path: deps
+          key: ${{ steps.keys.outputs.deps_key }}-${{ steps.keys.outputs.lockfile_key }}
+          restore-keys: |
+            ${{ steps.keys.outputs.deps_key }}-
+      - uses: actions/cache@v2.1.0
+        id: build_cache
         with:
           path: _build
-          key: ${{ steps.keys.outputs.env_key }}-${{ steps.keys.outputs.version_key }}-${{ steps.keys.outputs.files_key }}
+          key: ${{ steps.keys.outputs.build_key }}-${{ steps.keys.outputs.version_key }}-${{ steps.keys.outputs.files_key }}
           restore-keys: |
-            ${{ steps.keys.outputs.env_key }}-${{ steps.keys.outputs.version_key }}-
-            ${{ steps.keys.outputs.env_key }}-
+            ${{ steps.keys.outputs.build_key }}-${{ steps.keys.outputs.version_key }}-
+            ${{ steps.keys.outputs.build_key }}-
       - name: Install dependencies
-        if: steps.cache_deps.outputs['cache-hit'] != 'true'
+        if: steps.deps_cache.outputs['cache-hit'] != 'true'
         run: mix deps.get
       - name: Compile
-        if: steps.cache_build.outputs['cache-hit'] != 'true'
-        run: mix compile
+        if: steps.build_cache.outputs['cache-hit'] != 'true'
+        run: mix compile --warnings-as-errors
+      # job steps
       - name: Run credo
         run: mix credo --strict
 
@@ -160,36 +174,42 @@ jobs:
       MIX_ENV: dev
 
     steps:
+      # shared steps
       - uses: actions/checkout@v2
       - uses: doughsay/setup-elixir@1148b8ff819424a2efa48ff89af3ccc114c1fc39
         id: setup
         with:
-          otp-version: "23.x"
-          elixir-version: "1.10.x"
-      - uses: actions/cache@v2.1.0
-        id: cache_deps
-        with:
-          path: deps
-          key: ${{ runner.os }}-${{ hashFiles('mix.lock') }}
+          otp-version: ${{ env.OTP_VERSION_SPEC }}
+          elixir-version: ${{ env.ELIXIR_VERSION_SPEC }}
       - name: Cache Keys
         id: keys
         run: |
-          echo ::set-output name=env_key::${{ runner.os }}-${{ env.MIX_ENV }}
+          echo ::set-output name=deps_key::deps-${{ runner.os }}
+          echo ::set-output name=lockfile_key::${{ hashFiles('mix.lock') }}
+          echo ::set-output name=build_key::build-${{ runner.os }}-${{ env.MIX_ENV }}
           echo ::set-output name=version_key::${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}
           echo ::set-output name=files_key::${{ hashFiles('{lib/**/*.ex,test/**/*.ex,mix.lock}') }}
       - uses: actions/cache@v2.1.0
-        id: cache_build
+        id: deps_cache
+        with:
+          path: deps
+          key: ${{ steps.keys.outputs.deps_key }}-${{ steps.keys.outputs.lockfile_key }}
+          restore-keys: |
+            ${{ steps.keys.outputs.deps_key }}-
+      - uses: actions/cache@v2.1.0
+        id: build_cache
         with:
           path: _build
-          key: ${{ steps.keys.outputs.env_key }}-${{ steps.keys.outputs.version_key }}-${{ steps.keys.outputs.files_key }}
+          key: ${{ steps.keys.outputs.build_key }}-${{ steps.keys.outputs.version_key }}-${{ steps.keys.outputs.files_key }}
           restore-keys: |
-            ${{ steps.keys.outputs.env_key }}-${{ steps.keys.outputs.version_key }}-
-            ${{ steps.keys.outputs.env_key }}-
+            ${{ steps.keys.outputs.build_key }}-${{ steps.keys.outputs.version_key }}-
+            ${{ steps.keys.outputs.build_key }}-
       - name: Install dependencies
-        if: steps.cache_deps.outputs['cache-hit'] != 'true'
+        if: steps.deps_cache.outputs['cache-hit'] != 'true'
         run: mix deps.get
       - name: Compile
-        if: steps.cache_build.outputs['cache-hit'] != 'true'
-        run: mix compile
+        if: steps.build_cache.outputs['cache-hit'] != 'true'
+        run: mix compile --warnings-as-errors
+      # job steps
       - name: Run dialyzer
         run: mix dialyzer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on: push
 
 env:
   MIX_ENV: test
+  OTP_VERSION_SPEC: "23.x"
+  ELIXIR_VERSION_SPEC: "1.10.x"
 
 jobs:
   format:
@@ -13,12 +15,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1.3
+      - uses: doughsay/setup-elixir@1148b8ff819424a2efa48ff89af3ccc114c1fc39
+        id: setup
         with:
-          otp-version: "23.x"
-          elixir-version: "1.10.x"
+          otp-version: ${{ env.OTP_VERSION_SPEC }}
+          elixir-version: ${{ env.ELIXIR_VERSION_SPEC }}
       - name: Check formatted
-        run: mix format --check-formatted
+        run: |
+          echo ${{ steps.setup.outputs['otp-version'] }}
+          echo ${{ steps.setup.outputs['elixir-version'] }}
+          mix format --check-formatted
 
   compile:
     name: Compile
@@ -27,29 +33,30 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1.3
+      - uses: doughsay/setup-elixir@1148b8ff819424a2efa48ff89af3ccc114c1fc39
+        id: setup
         with:
-          otp-version: "23.x"
-          elixir-version: "1.10.x"
+          otp-version: ${{ env.OTP_VERSION_SPEC }}
+          elixir-version: ${{ env.ELIXIR_VERSION_SPEC }}
       - uses: actions/cache@v2.1.0
-        id: cache-mix
+        id: cache_deps
         with:
           path: deps
-          key: ${{ runner.os }}-mix-v6-${{ hashFiles('mix.lock') }}
+          key: ${{ runner.os }}-${{ hashFiles('mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-mix-v6-
+            ${{ runner.os }}-
       - uses: actions/cache@v2.1.0
-        id: cache-build
+        id: cache_build
         with:
           path: _build
-          key: ${{ runner.os }}-build-v4-${{ hashFiles('lib/**/*.ex') }}${{ hashFiles('test/**/*.ex') }}${{ hashFiles('mix.lock') }}
+          key: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}-${{ hashFiles('{lib/**/*.ex,test/**/*.ex,mix.lock}') }}
           restore-keys: |
-            ${{ runner.os }}-build-v4-
+            ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}-
       - name: Install dependencies
-        if: steps.cache-mix.outputs.cache-hit != 'true'
+        if: steps.cache_deps.outputs['cache-hit'] != 'true'
         run: mix deps.get
       - name: Compile
-        if: steps.cache-build.outputs.cache-hit != 'true'
+        if: steps.cache_build.outputs['cache-hit'] != 'true'
         run: mix compile --warnings-as-errors
 
   test:
@@ -61,18 +68,29 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1.3
+      - uses: doughsay/setup-elixir@1148b8ff819424a2efa48ff89af3ccc114c1fc39
+        id: setup
         with:
           otp-version: "23.x"
           elixir-version: "1.10.x"
       - uses: actions/cache@v2.1.0
+        id: cache_deps
         with:
           path: deps
-          key: ${{ runner.os }}-mix-v6-${{ hashFiles('mix.lock') }}
+          key: ${{ runner.os }}-${{ hashFiles('mix.lock') }}
       - uses: actions/cache@v2.1.0
+        id: cache_build
         with:
           path: _build
-          key: ${{ runner.os }}-build-v4-${{ hashFiles('lib/**/*.ex') }}${{ hashFiles('test/**/*.ex') }}${{ hashFiles('mix.lock') }}
+          key: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}-${{ hashFiles('{lib/**/*.ex,test/**/*.ex,mix.lock}') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}-
+      - name: Install dependencies
+        if: steps.cache_deps.outputs['cache-hit'] != 'true'
+        run: mix deps.get
+      - name: Compile
+        if: steps.cache_build.outputs['cache-hit'] != 'true'
+        run: mix compile
       - name: Run tests
         run: mix coveralls.json
       - uses: codecov/codecov-action@v1
@@ -89,18 +107,29 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1.3
+      - uses: doughsay/setup-elixir@1148b8ff819424a2efa48ff89af3ccc114c1fc39
+        id: setup
         with:
           otp-version: "23.x"
           elixir-version: "1.10.x"
       - uses: actions/cache@v2.1.0
+        id: cache_deps
         with:
           path: deps
-          key: ${{ runner.os }}-mix-v6-${{ hashFiles('mix.lock') }}
+          key: ${{ runner.os }}-${{ hashFiles('mix.lock') }}
       - uses: actions/cache@v2.1.0
+        id: cache_build
         with:
           path: _build
-          key: ${{ runner.os }}-build-v4-${{ hashFiles('lib/**/*.ex') }}${{ hashFiles('test/**/*.ex') }}${{ hashFiles('mix.lock') }}
+          key: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}-${{ hashFiles('{lib/**/*.ex,test/**/*.ex,mix.lock}') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}-
+      - name: Install dependencies
+        if: steps.cache_deps.outputs['cache-hit'] != 'true'
+        run: mix deps.get
+      - name: Compile
+        if: steps.cache_build.outputs['cache-hit'] != 'true'
+        run: mix compile
       - name: Run credo
         run: mix credo --strict
 
@@ -114,27 +143,28 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1.3
+      - uses: doughsay/setup-elixir@1148b8ff819424a2efa48ff89af3ccc114c1fc39
+        id: setup
         with:
           otp-version: "23.x"
           elixir-version: "1.10.x"
       - uses: actions/cache@v2.1.0
-        id: cache-build-dev
+        id: cache_deps
+        with:
+          path: deps
+          key: ${{ runner.os }}-${{ hashFiles('mix.lock') }}
+      - uses: actions/cache@v2.1.0
+        id: cache_build
         with:
           path: _build
-          key: ${{ runner.os }}-build-dev-v4-${{ hashFiles('lib/**/*.ex') }}${{ hashFiles('test/**/*.ex') }}${{ hashFiles('mix.lock') }}
+          key: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}-${{ hashFiles('{lib/**/*.ex,test/**/*.ex,mix.lock}') }}
           restore-keys: |
-            ${{ runner.os }}-build-dev-v4-
-      - uses: actions/cache@v2.1.0
-        with:
-          path: plts
-          key: ${{ runner.os }}-plts-v5-${{ hashFiles('lib/**/*.ex') }}${{ hashFiles('test/**/*.ex') }}${{ hashFiles('mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-plts-v5-
+            ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}-
       - name: Install dependencies
+        if: steps.cache_deps.outputs['cache-hit'] != 'true'
         run: mix deps.get
       - name: Compile
-        if: steps.cache-build-dev.outputs.cache-hit != 'true'
+        if: steps.cache_build.outputs['cache-hit'] != 'true'
         run: mix compile
       - name: Run dialyzer
         run: mix dialyzer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,7 @@ jobs:
           otp-version: ${{ env.OTP_VERSION_SPEC }}
           elixir-version: ${{ env.ELIXIR_VERSION_SPEC }}
       - name: Check formatted
-        run: |
-          echo ${{ steps.setup.outputs['otp-version'] }}
-          echo ${{ steps.setup.outputs['elixir-version'] }}
-          mix format --check-formatted
+        run: mix format --check-formatted
 
   compile:
     name: Compile
@@ -45,13 +42,20 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-
+      - name: Cache Keys
+        id: keys
+        run: |
+          echo ::set-output name=env_key::${{ runner.os }}-${{ env.MIX_ENV }}
+          echo ::set-output name=version_key::${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}
+          echo ::set-output name=files_key::${{ hashFiles('{lib/**/*.ex,test/**/*.ex,mix.lock}') }}
       - uses: actions/cache@v2.1.0
         id: cache_build
         with:
           path: _build
-          key: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}-${{ hashFiles('{lib/**/*.ex,test/**/*.ex,mix.lock}') }}
+          key: ${{ steps.keys.outputs.env_key }}-${{ steps.keys.outputs.version_key }}-${{ steps.keys.outputs.files_key }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}-
+            ${{ steps.keys.outputs.env_key }}-${{ steps.keys.outputs.version_key }}-
+            ${{ steps.keys.outputs.env_key }}-
       - name: Install dependencies
         if: steps.cache_deps.outputs['cache-hit'] != 'true'
         run: mix deps.get
@@ -78,13 +82,20 @@ jobs:
         with:
           path: deps
           key: ${{ runner.os }}-${{ hashFiles('mix.lock') }}
+      - name: Cache Keys
+        id: keys
+        run: |
+          echo ::set-output name=env_key::${{ runner.os }}-${{ env.MIX_ENV }}
+          echo ::set-output name=version_key::${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}
+          echo ::set-output name=files_key::${{ hashFiles('{lib/**/*.ex,test/**/*.ex,mix.lock}') }}
       - uses: actions/cache@v2.1.0
         id: cache_build
         with:
           path: _build
-          key: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}-${{ hashFiles('{lib/**/*.ex,test/**/*.ex,mix.lock}') }}
+          key: ${{ steps.keys.outputs.env_key }}-${{ steps.keys.outputs.version_key }}-${{ steps.keys.outputs.files_key }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}-
+            ${{ steps.keys.outputs.env_key }}-${{ steps.keys.outputs.version_key }}-
+            ${{ steps.keys.outputs.env_key }}-
       - name: Install dependencies
         if: steps.cache_deps.outputs['cache-hit'] != 'true'
         run: mix deps.get
@@ -117,13 +128,20 @@ jobs:
         with:
           path: deps
           key: ${{ runner.os }}-${{ hashFiles('mix.lock') }}
+      - name: Cache Keys
+        id: keys
+        run: |
+          echo ::set-output name=env_key::${{ runner.os }}-${{ env.MIX_ENV }}
+          echo ::set-output name=version_key::${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}
+          echo ::set-output name=files_key::${{ hashFiles('{lib/**/*.ex,test/**/*.ex,mix.lock}') }}
       - uses: actions/cache@v2.1.0
         id: cache_build
         with:
           path: _build
-          key: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}-${{ hashFiles('{lib/**/*.ex,test/**/*.ex,mix.lock}') }}
+          key: ${{ steps.keys.outputs.env_key }}-${{ steps.keys.outputs.version_key }}-${{ steps.keys.outputs.files_key }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}-
+            ${{ steps.keys.outputs.env_key }}-${{ steps.keys.outputs.version_key }}-
+            ${{ steps.keys.outputs.env_key }}-
       - name: Install dependencies
         if: steps.cache_deps.outputs['cache-hit'] != 'true'
         run: mix deps.get
@@ -153,13 +171,20 @@ jobs:
         with:
           path: deps
           key: ${{ runner.os }}-${{ hashFiles('mix.lock') }}
+      - name: Cache Keys
+        id: keys
+        run: |
+          echo ::set-output name=env_key::${{ runner.os }}-${{ env.MIX_ENV }}
+          echo ::set-output name=version_key::${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}
+          echo ::set-output name=files_key::${{ hashFiles('{lib/**/*.ex,test/**/*.ex,mix.lock}') }}
       - uses: actions/cache@v2.1.0
         id: cache_build
         with:
           path: _build
-          key: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}-${{ hashFiles('{lib/**/*.ex,test/**/*.ex,mix.lock}') }}
+          key: ${{ steps.keys.outputs.env_key }}-${{ steps.keys.outputs.version_key }}-${{ steps.keys.outputs.files_key }}
           restore-keys: |
-            ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup.outputs['otp-version'] }}-${{ steps.setup.outputs['elixir-version'] }}-
+            ${{ steps.keys.outputs.env_key }}-${{ steps.keys.outputs.version_key }}-
+            ${{ steps.keys.outputs.env_key }}-
       - name: Install dependencies
         if: steps.cache_deps.outputs['cache-hit'] != 'true'
         run: mix deps.get

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![SourceLevel](https://app.sourcelevel.io/github/doughsay/afk.svg)](https://app.sourcelevel.io/github/doughsay/afk)
 [![Hex.pm Version](https://img.shields.io/hexpm/v/afk.svg?style=flat)](https://hex.pm/packages/afk)
 [![License](https://img.shields.io/hexpm/l/afk.svg)](LICENSE.md)
-[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=doughsay/afk)](https://dependabot.com)
 
 A library for modeling the internal state of a computer keyboard. It supports
 arbitrary layouts with any number of layers, and outputs a basic 6-key HID

--- a/lib/afk/keycode/transparent.ex
+++ b/lib/afk/keycode/transparent.ex
@@ -12,7 +12,6 @@ defmodule AFK.Keycode.Transparent do
   @doc """
   Creates a `Transparent` keycode.
 
-
   ## Examples
 
       iex> new()

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule AFK.MixProject do
 
   defp dialyzer do
     [
-      plt_file: {:no_warn, "plts/afk.plt"},
+      plt_core_path: "_build/#{Mix.env()}",
       flags: [:unmatched_returns, :error_handling, :underspecs]
     ]
   end


### PR DESCRIPTION
Multiple changes to the CI script:

* CI can now run locally using [act](https://github.com/nektos/act). Caching doesn't work locally (also, one of the cache keys can't be generated locally, see here: https://github.com/nektos/act/issues/324).
* Elixir and OTP versions DRYed into variables.
* Cache keys include Elixir and OTP versions, to help invalidate stale caches when versions change
  * This is done using this: https://github.com/actions/setup-elixir/pull/36 (waiting on approval and release to update action reference)
* Dialyzer PLTs have been moved into _build and are cached alongside it.
* The steps have been refactored to all be identical between jobs except the one or two steps that are relevant to that job.  This prepares us for "composite actions", which is an upcoming feature from github.  This will drastically DRY up the CI script.
* The codecov token has been removed, they now support actions officially